### PR TITLE
content에 대한 purifier 처리를 service에서 module controller로 이동

### DIFF
--- a/src/Controllers/BoardModuleController.php
+++ b/src/Controllers/BoardModuleController.php
@@ -42,12 +42,14 @@ use Xpressengine\Plugins\Board\Models\Board;
 use Xpressengine\Plugins\Board\Modules\BoardModule;
 use Xpressengine\Plugins\Board\BoardPermissionHandler;
 use Xpressengine\Plugins\Board\Models\BoardSlug;
-use Xpressengine\Plugins\Board\Purifier;
 use Xpressengine\Plugins\Board\Services\BoardService;
 use Xpressengine\Plugins\Board\UrlHandler;
 use Xpressengine\Plugins\Board\Validator;
 use Xpressengine\Routing\InstanceConfig;
 use Xpressengine\Support\Exceptions\AccessDeniedHttpException;
+use Xpressengine\Support\Purifier;
+use Xpressengine\Support\PurifierModules\Html5;
+use Xpressengine\Editor\PurifierModules\EditorContent;
 use Xpressengine\User\Models\User;
 use Xpressengine\User\UserInterface;
 
@@ -300,6 +302,16 @@ class BoardModuleController extends Controller
             throw new AccessDeniedHttpException;
         }
 
+        $purifier = new Purifier();
+        $purifier->allowModule(EditorContent::class);
+        $purifier->allowModule(HTML5::class);
+
+        $inputs = $request->all();
+        $originInputs = $request->originAll();
+        $inputs['title'] = htmlspecialchars($originInputs['title'], ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+        $inputs['content'] = $purifier->purify($originInputs['content']);
+        $request->replace($inputs);
+
         // 유표성 체크
         $this->validate($request, $validator->getCreateRule(Auth::user(), $this->config));
 
@@ -413,6 +425,16 @@ class BoardModuleController extends Controller
                 'referrer' => $this->urlHandler->get('edit', ['id' => $item->id]),
             ]));
         }
+
+        $purifier = new Purifier();
+        $purifier->allowModule(EditorContent::class);
+        $purifier->allowModule(HTML5::class);
+
+        $inputs = $request->all();
+        $originInputs = $request->originAll();
+        $inputs['title'] = htmlspecialchars($originInputs['title'], ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+        $inputs['content'] = $purifier->purify($originInputs['content']);
+        $request->replace($inputs);
 
         $this->validate($request, $validator->getEditRule(Auth::user(), $this->config));
 

--- a/src/Services/BoardService.php
+++ b/src/Services/BoardService.php
@@ -31,7 +31,6 @@ use Xpressengine\Plugins\Board\Models\Board;
 use Xpressengine\Support\Exceptions\AccessDeniedHttpException;
 use Xpressengine\Support\PurifierModules\Html5;
 use Xpressengine\User\UserInterface;
-use Xpressengine\Support\Purifier;
 
 /**
  * BoardService
@@ -270,14 +269,8 @@ class BoardService
             $request->request->set('certifyKey', $identifyManager->hash($request->get('certifyKey')));
         }
 
-        $purifier = new Purifier();
-        $purifier->allowModule(EditorTool::class);
-        $purifier->allowModule(HTML5::class);
-
         $inputs = $request->request->all();
         $inputs['instanceId'] = $config->get('boardId');
-        $inputs['title'] = htmlspecialchars($request->originAll()['title'], ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-        $inputs['content'] = $purifier->purify($request->originAll()['content']);
 
         /** @var \Xpressengine\Editor\AbstractEditor $editor */
         $editor = XeEditor::get($config->get('boardId'));
@@ -316,19 +309,13 @@ class BoardService
             $request->request->set('certifyKey', $identifyManager->hash($newCertifyKey));
         }
 
-        $purifier = new Purifier();
-        $purifier->allowModule(EditorTool::class);
-        $purifier->allowModule(HTML5::class);
-
-        $inputs = $request->all();
-        $inputs['title'] = htmlspecialchars($request->originAll()['title'], ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
-        $inputs['content'] = $purifier->purify($request->originAll()['content']);
-
         if ($request->get('status') == Board::STATUS_NOTICE) {
             $item->status = Board::STATUS_NOTICE;
         } elseif ($request->get('status') != Board::STATUS_NOTICE && $item->status == Board::STATUS_NOTICE) {
             $item->status = Board::STATUS_PUBLIC;
         }
+
+        $inputs = $request->all();
 
         /** @var \Xpressengine\Editor\AbstractEditor $editor */
         $editor = XeEditor::get($config->get('boardId'));


### PR DESCRIPTION
BoardService에서 처리하던 HTMLPurifier를 이용한 HTML태그 정리 로직을 BoardModuleController로 이동

validate를 module controller에서 수행하기 때문에 middleware에서 콘텐츠가 비워질 경우 validator에서 중단 되어 service로 전달되지 않음

purifier 적용을 module controller로 옮겨 content에 게시판이 허용하는 태그를 정상적으로 반영할 수 있도록 함