### PR TITLE
보드 게시물 리스트 위젯에 조회순 정렬 옵션 추가

### DIFF
--- a/components/Widgets/ArticleList/ArticleListWidget.php
+++ b/components/Widgets/ArticleList/ArticleListWidget.php
@@ -199,6 +199,13 @@ class ArticleListWidget extends AbstractWidget
                 );
 
                 $query->when(
+                    $orderType === 'read_count',
+                    function ($query) {
+                        $query->orderBy('read_count', 'desc')->orderBy('head', 'desc');
+                    }
+                );
+
+                $query->when(
                     $orderType === 'recentlyCreated',
                     function ($query) {
                         $query->orderBy(Board::CREATED_AT, 'desc')->orderBy('head', 'desc');

--- a/components/Widgets/ArticleList/views/setting.blade.php
+++ b/components/Widgets/ArticleList/views/setting.blade.php
@@ -1,10 +1,11 @@
 <div class="form-group">
     <label>정렬</label>
     <select name="order_type" class="form-control">
-        <option value="recentlyCreated" @if(array_get($args, 'order_type') == 'recentlyCreated') selected="selected" @endif >{{xe_trans('board::recentlyCreated')}}</option>
-        <option value="recentlyUpdated" @if(array_get($args, 'order_type') == 'recentlyUpdated') selected="selected" @endif >{{xe_trans('board::recentlyUpdated')}}</option>
-        <option value="assent_count" @if(array_get($args, 'order_type') == 'assent_count') selected="selected" @endif >{{xe_trans('board::assentOrder')}}</option>
-        <option value="random" @if(array_get($args, 'order_type') == 'random') selected="selected" @endif >랜덤</option>
+        <option value="recentlyCreated" @if(array_get($args, 'order_type') == 'recentlyCreated') selected="selected" @endif >{{ xe_trans('board::recentlyCreated') }}</option>
+        <option value="recentlyUpdated" @if(array_get($args, 'order_type') == 'recentlyUpdated') selected="selected" @endif >{{ xe_trans('board::recentlyUpdated') }}</option>
+        <option value="assent_count" @if(array_get($args, 'order_type') == 'assent_count') selected="selected" @endif >{{ xe_trans('board::assentOrder') }}</option>
+        <option value="read_count" @if(array_get($args, 'order_type') == 'read_count') selected="selected" @endif >{{ xe_trans('board::readOrder') }}</option>
+        <option value="random" @if(array_get($args, 'order_type') == 'random') selected="selected" @endif >{{ xe_trans('board::randomOrder') }}</option>
     </select>
 </div>
 

--- a/langs/lang.php
+++ b/langs/lang.php
@@ -226,6 +226,14 @@ return [
         'ko' => '많은 추천을 받은 순서로 정렬합니다.',
         'en' => 'Sort by assent count',
     ],
+    'readOrder' => [
+        'ko' => '조회순',
+        'en' => 'Most viewed',
+    ],
+    'randomOrder' => [
+        'ko' => '랜덤',
+        'en' => 'Random',
+    ],
     'moveToTrash' => [
         'ko' => '휴지통으로 이동',
         'en' => 'Move to Trash',


### PR DESCRIPTION
보드 게시물 리스트 위젯(ArticleListWidget) 의 위젯 설정값인 '정렬'에 '조회순' 항목을 추가 및 '랜덤' 항목 다국어 처리를 대응하였습니다.

![image](https://user-images.githubusercontent.com/25261591/152510207-60c7721d-39f0-4317-b3a7-39d925d31459.png)
